### PR TITLE
is_public should be yes

### DIFF
--- a/gpvcmupdate.py
+++ b/gpvcmupdate.py
@@ -97,7 +97,7 @@ def main():
         sys.stdout.write("Creating Metadata Files")
         with open(metadata, "w") as outfile:
             outfile.write("comment=\"" + os.getenv('VMCATCHER_EVENT_SL_COMMENTS') + "\"\n")
-            outfile.write("is_public=\"no\"\n")
+            outfile.write("is_public=\"yes\"\n")
             if args.protected:
                 outfile.write("is_protected=\"yes\"\n")
             else:


### PR DESCRIPTION
is_public should be yes, since the images registered should be visible by all by default. Only private images should be not public (vmcatcher would need a change to give information about non-public images, waiting for that, we can suppose that all the images are public).
